### PR TITLE
Add main option into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "swipe-js",
   "version": "2.0.2",
+  "main": "swipe.js",
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
The option is available in `bower.json` but not in `package.json`. It is needed to fully resolve the package.