### PR TITLE
Fix errant exclamation mark

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -1,4 +1,4 @@
-/*!
+/*
  * Swipe 2.0.3
  *
  * Brad Birdsall & Felix Liu
@@ -7,7 +7,7 @@
 */
 
 // if the module has no dependencies, the above pattern can be simplified to
-(function (root, factory) {
+!(function (root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define([], function(){


### PR DESCRIPTION
I'm getting a `Uncaught TypeError: object is not a function` error without the `!`. Comparing to the .min version, it appears the exclamation mark ended up in the comments section somehow.