### PR TITLE
Update CSS code to insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Also Swipe needs just a few styles added to your stylesheet:
   float:left;
   width:100%;
   position: relative;
+  overflow: hidden;
 }
 ```
 


### PR DESCRIPTION
I faced an issue where my vignettes overflowed over the next ones. It has happened because my images exceed 100% of the screen width. To solve that I needed to add `overflow: hidden;` to the `.swipe-wrap > div` selector.