### PR TITLE
preventDefault on mousedown for desktop safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ window.mySwipe = new Swipe(element, {
     </footer>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script src="build/swipe.min.js"></script>
+    <script src="swipe.js"></script>
     <script>
 
 // pure JS
@@ -174,7 +174,7 @@ var element = document.getElementById('mySwipe'),
 window.mySwipe = new Swipe(element, {
   startSlide: 0,
   auto: 3000,
-  draggable: false,
+  draggable: true,
   autoRestart: false,
   continuous: true,
   disableScroll: true,

--- a/swipe.js
+++ b/swipe.js
@@ -89,7 +89,7 @@
       // determine width of each slide
       width = container.getBoundingClientRect().width || container.offsetWidth;
 
-      element.style.width = (slides.length * width) + 'px';
+      element.style.width = (slides.length * width * 2) + 'px';
 
       // stack elements
       var pos = slides.length;
@@ -338,7 +338,14 @@
 
       },
       start: function(event) {
-        var touches = isMouseEvent(event) ? event : event.touches[0];
+        var touches;
+
+        if (isMouseEvent(event)) {
+          touches = event;
+          event.preventDefault(); // For desktop Safari drag
+        } else {
+          touches = event.touches[0];
+        }
 
         // measure start values
         start = {


### PR DESCRIPTION
This is bug fix for Safari on mac with dragging option on.
mousedown event toggles drag mode after a short delay.