### PR TITLE
Add parseInt() to calculation var to in slide()

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -180,7 +180,7 @@
           // if going forward but to < index, use to = slides.length + to
           // if going backward but to > index, use to = -slides.length + to
           if (direction !== natural_direction) {
-            to =  -direction * slides.length + to;
+            to = (-direction * slides.length) + parseInt(to, 10);
           }
 
         }


### PR DESCRIPTION
To ensure that variable is not type of string, the calculation of variable to in method slide() was adjusted.
This solves #25 