### PR TITLE
Adjust type of variable to in slide()

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -163,6 +163,9 @@
 
     function slide(to, slideSpeed) {
 
+      // ensure to is of type 'number'
+      to = typeof to !== 'number' ? parseInt(to, 10) : to;
+      
       // do nothing if already on requested slide
       if (index === to) {
         return;


### PR DESCRIPTION
To ensure variable to has correct type to compare to variable index and to calculate variable to if continuous is enabled, type of variable to is set to number.
This solves Issue #25.