### PR TITLE
Angular.swipe.js: Added $timeout so swipe isn't inited too early

### DIFF
--- a/angular-swipe/angular.swipe.js
+++ b/angular-swipe/angular.swipe.js
@@ -6,7 +6,7 @@
     .directive('swipeSlider', swipeSlider)
     .directive('swipeItem', swipeItem);
 
-  function swipeWrap() {
+  function swipeWrap($timeout) {
     return {
       restrict: 'EA',
       replace: true,
@@ -14,7 +14,9 @@
       controllerAs: 'SwipeCtrl',
       link: function(scope, element, attrs, Controller) {
         // Kickstart the Swipe Slider
-        Controller.init();
+        // Use $timeout so the controller will be inited at the end of the cycle
+        // This is needed when you are using ng-repeat and other async stuff
+        $timeout(Controller.init);
       }
     };
   }


### PR DESCRIPTION
Calling Controller.init from $timeout to ensure everything is ready. This is needed if you're using ng-repeat or other async functions.