### PR TITLE
Webpack bundle fix. 

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -26,6 +26,7 @@
     root.Swipe = factory(root);
   }
 }(this, function (root) {
+  root = root.self || this;
   var _document = root.document || this.document;
 
   function Swipe(container, options) {


### PR DESCRIPTION
Check if `root` is ref to window, if not set `this` as root.